### PR TITLE
Align preview structure with popup

### DIFF
--- a/src/options/components.css
+++ b/src/options/components.css
@@ -19,7 +19,7 @@ body {
   box-shadow: var(--shadow-md);
 }
 
-h1 {
+h1.header {
   font-size: var(--font-size-xxl);
   display: flex;
   align-items: center;
@@ -29,7 +29,7 @@ h1 {
   padding-bottom: 12px;
 }
 
-h1::after {
+h1.header::after {
   content: "";
   position: absolute;
   bottom: 0;
@@ -47,7 +47,7 @@ h1::after {
   );
 }
 
-h1 img {
+h1.header img {
   margin-right: var(--spacing-md);
 }
 
@@ -374,6 +374,8 @@ input[type="text"]:focus {
   padding: var(--spacing-md);
   text-align: center;
   font-weight: var(--font-weight-medium);
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 /* Remove main header styling from popup title */

--- a/src/options/components.css
+++ b/src/options/components.css
@@ -376,6 +376,11 @@ input[type="text"]:focus {
   font-weight: var(--font-weight-medium);
 }
 
+/* Remove main header styling from popup title */
+.preview-container #popup-title::after {
+  display: none;
+}
+
 
 .neapolitan-stripe {
   display: flex;

--- a/src/options/components.css
+++ b/src/options/components.css
@@ -358,7 +358,7 @@ input[type="text"]:focus {
   font-size: var(--font-size-md);
 }
 
-.popup-preview {
+.environment-links {
   width: 220px;
   border: 1px solid #ddd;
   border-radius: var(--radius-md);
@@ -368,7 +368,7 @@ input[type="text"]:focus {
   font-size: var(--font-size-md);
 }
 
-.preview-header {
+#popup-title {
   background-color: var(--vanilla-base);
   color: var(--text-primary);
   padding: var(--spacing-md);
@@ -376,23 +376,40 @@ input[type="text"]:focus {
   font-weight: var(--font-weight-medium);
 }
 
-.preview-stripe {
+
+.neapolitan-stripe {
   display: flex;
   height: 4px;
 }
 
-.preview-stripe div {
+.neapolitan-stripe div {
   height: 100%;
   width: 33.33%;
 }
 
-.preview-list {
+/* Top stripe is subtle */
+.neapolitan-stripe-top {
+  opacity: 0.6;
+}
+
+/* Bottom stripe has shadow for depth */
+.neapolitan-stripe-bottom {
+  position: relative;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 8px;
+}
+
+html[data-theme="dark"] .neapolitan-stripe-bottom,
+body.theme-dark .neapolitan-stripe-bottom {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+#link-list {
   list-style: none;
   padding: var(--spacing-md) 0;
   margin: 0;
 }
-
-.preview-link {
+#link-list a {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
@@ -403,13 +420,11 @@ input[type="text"]:focus {
   border-left: 4px solid transparent;
   cursor: pointer;
 }
-
-.preview-link.active {
+#link-list a.active {
   background-color: var(--strawberry-dark);
   border-left-color: var(--env-staging-accent);
 }
-
-.preview-badge {
+.icon-badge {
   width: 20px;
   height: 20px;
   border-radius: var(--radius-round);
@@ -418,25 +433,20 @@ input[type="text"]:focus {
   justify-content: center;
   box-shadow: var(--shadow-sm);
 }
-
-.dev-badge {
+.dev-icon-badge {
   background-color: white;
 }
-
-.staging-badge {
+.staging-icon-badge {
   background-color: var(--strawberry-base);
 }
-
-.prod-badge {
+.prod-icon-badge {
   background-color: var(--vanilla-base);
 }
-
-.preview-emoji {
+.emoji-icon {
   font-size: var(--font-size-sm);
   filter: drop-shadow(0 0 1px rgba(0,0,0,0.8));
 }
-
-.preview-text {
+.icon-text {
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-bold);
   display: none;
@@ -444,11 +454,10 @@ input[type="text"]:focus {
 }
 
 /* When emoji icons are disabled */
-.emoji-disabled .preview-emoji {
+.emoji-disabled .emoji-icon {
   display: none;
 }
-
-.emoji-disabled .preview-text {
+.emoji-disabled .icon-text {
   display: inline;
 }
 
@@ -1079,56 +1088,56 @@ body.theme-dark .nutrition-label a {
 }
 
 /* Dark mode popup preview overrides */
-html[data-theme="dark"] .popup-preview,
-body.theme-dark .popup-preview {
+html[data-theme="dark"] .environment-links,
+body.theme-dark .environment-links {
   background-color: var(--bg-primary);
   color: var(--text-primary);
   border-color: rgba(255, 255, 255, 0.2);
 }
 
-html[data-theme="dark"] .preview-header,
-body.theme-dark .preview-header {
+html[data-theme="dark"] #popup-title,
+body.theme-dark #popup-title {
   background-color: var(--vanilla-base);
   color: #000000;
 }
 
-html[data-theme="dark"] .preview-link,
-body.theme-dark .preview-link {
+html[data-theme="dark"] #link-list a,
+body.theme-dark #link-list a {
   background-color: rgba(255, 255, 255, 0.1);
   color: var(--text-primary);
 }
 
-html[data-theme="dark"] .preview-link:hover,
-body.theme-dark .preview-link:hover {
+html[data-theme="dark"] #link-list a:hover,
+body.theme-dark #link-list a:hover {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
-html[data-theme="dark"] .preview-link.active,
-body.theme-dark .preview-link.active {
+html[data-theme="dark"] #link-list a.active,
+body.theme-dark #link-list a.active {
   background-color: var(--strawberry-base);
   color: #000000;
   border-left-color: var(--strawberry-dark);
   font-weight: var(--font-weight-bold);
 }
 
-html[data-theme="dark"] .preview-badge.dev-badge,
-body.theme-dark .preview-badge.dev-badge {
+html[data-theme="dark"] .dev-icon-badge,
+body.theme-dark .dev-icon-badge {
   background-color: white;
   border: 1px solid rgba(255, 255, 255, 0.3);
 }
 
-html[data-theme="dark"] .preview-badge.staging-badge,
-body.theme-dark .preview-badge.staging-badge {
+html[data-theme="dark"] .staging-icon-badge,
+body.theme-dark .staging-icon-badge {
   background-color: var(--strawberry-base);
 }
 
-html[data-theme="dark"] .preview-badge.prod-badge,
-body.theme-dark .preview-badge.prod-badge {
+html[data-theme="dark"] .prod-icon-badge,
+body.theme-dark .prod-icon-badge {
   background-color: var(--vanilla-base);
 }
 
-html[data-theme="dark"] .preview-text,
-body.theme-dark .preview-text {
+html[data-theme="dark"] .icon-text,
+body.theme-dark .icon-text {
   color: #000000;
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -263,38 +263,43 @@
           <div class="settings-column">
             <div class="preview-container">
               <h4>Popup Preview:</h4>
-              <div class="popup-preview">
+              <div id="environment-links" class="environment-links">
                 <!-- Popup Preview Content -->
-                <div class="preview-header">Switch Environment</div>
-                <div class="preview-stripe">
-                  <div class="stripe-vanilla"></div>
-                  <div class="stripe-strawberry"></div>
+                <div class="neapolitan-stripe neapolitan-stripe-top">
                   <div class="stripe-chocolate"></div>
+                  <div class="stripe-strawberry"></div>
+                  <div class="stripe-vanilla"></div>
                 </div>
-                <ul class="preview-list">
+                <h1 id="popup-title">Switch Environment</h1>
+                <div class="neapolitan-stripe neapolitan-stripe-bottom">
+                  <div class="stripe-chocolate"></div>
+                  <div class="stripe-strawberry"></div>
+                  <div class="stripe-vanilla"></div>
+                </div>
+                <ul id="link-list">
                   <li>
-                    <a class="preview-link">
-                      <span class="preview-badge dev-badge">
-                        <span class="preview-emoji" id="preview-dev-emoji">🍫</span>
-                        <span class="preview-text" id="preview-dev-text">D</span>
+                    <a>
+                      <span class="icon-badge dev-icon-badge">
+                        <span class="emoji-icon" id="preview-dev-emoji">🍫</span>
+                        <span class="icon-text" id="preview-dev-text">D</span>
                       </span>
                       <span>Development</span>
                     </a>
                   </li>
                   <li>
-                    <a class="preview-link active">
-                      <span class="preview-badge staging-badge">
-                        <span class="preview-emoji" id="preview-staging-emoji">🍓</span>
-                        <span class="preview-text" id="preview-staging-text">S</span>
+                    <a class="active">
+                      <span class="icon-badge staging-icon-badge">
+                        <span class="emoji-icon" id="preview-staging-emoji">🍓</span>
+                        <span class="icon-text" id="preview-staging-text">S</span>
                       </span>
                       <span>Staging</span>
                     </a>
                   </li>
                   <li>
-                    <a class="preview-link">
-                      <span class="preview-badge prod-badge">
-                        <span class="preview-emoji" id="preview-prod-emoji">🍦</span>
-                        <span class="preview-text" id="preview-prod-text">P</span>
+                    <a>
+                      <span class="icon-badge prod-icon-badge">
+                        <span class="emoji-icon" id="preview-prod-emoji">🍦</span>
+                        <span class="icon-text" id="preview-prod-text">P</span>
                       </span>
                       <span>Production</span>
                     </a>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -571,7 +571,7 @@ function updateThemePreview() {
 // Update popup preview based on settings
 function updatePopupPreview() {
   const showEmoji = document.getElementById('show-emoji-icons').checked;
-  const popupPreview = document.querySelector('.popup-preview');
+  const popupPreview = document.getElementById('environment-links');
   
   if (showEmoji) {
     popupPreview.classList.remove('emoji-disabled');
@@ -594,7 +594,7 @@ function updatePopupPreview() {
   popupPreview.classList.add(`theme-${currentTheme}`);
   
   // Apply active state to the staging environment for demonstration
-  const links = document.querySelectorAll('.preview-link');
+  const links = document.querySelectorAll('#link-list a');
   links.forEach(link => {
     link.classList.remove('active');
   });


### PR DESCRIPTION
## Summary
- sync preview markup with popup structure
- switch options preview classes to match popup
- adjust preview update logic
- use common id for popup preview

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_684331e3a33083258962175010a4c1fb